### PR TITLE
chore: bump typescript-eslint in the minor_patch group

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
                 "husky": "^9.1.7",
                 "prettier": "^3.6.2",
                 "typescript": "^5.8.3",
-                "typescript-eslint": "^8.36.0"
+                "typescript-eslint": "^8.37.0"
             }
         },
         "node_modules/@babel/code-frame": {
@@ -1245,17 +1245,17 @@
             }
         },
         "node_modules/@typescript-eslint/eslint-plugin": {
-            "version": "8.36.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.36.0.tgz",
-            "integrity": "sha512-lZNihHUVB6ZZiPBNgOQGSxUASI7UJWhT8nHyUGCnaQ28XFCw98IfrMCG3rUl1uwUWoAvodJQby2KTs79UTcrAg==",
+            "version": "8.37.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.37.0.tgz",
+            "integrity": "sha512-jsuVWeIkb6ggzB+wPCsR4e6loj+rM72ohW6IBn2C+5NCvfUVY8s33iFPySSVXqtm5Hu29Ne/9bnA0JmyLmgenA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@eslint-community/regexpp": "^4.10.0",
-                "@typescript-eslint/scope-manager": "8.36.0",
-                "@typescript-eslint/type-utils": "8.36.0",
-                "@typescript-eslint/utils": "8.36.0",
-                "@typescript-eslint/visitor-keys": "8.36.0",
+                "@typescript-eslint/scope-manager": "8.37.0",
+                "@typescript-eslint/type-utils": "8.37.0",
+                "@typescript-eslint/utils": "8.37.0",
+                "@typescript-eslint/visitor-keys": "8.37.0",
                 "graphemer": "^1.4.0",
                 "ignore": "^7.0.0",
                 "natural-compare": "^1.4.0",
@@ -1269,7 +1269,7 @@
                 "url": "https://opencollective.com/typescript-eslint"
             },
             "peerDependencies": {
-                "@typescript-eslint/parser": "^8.36.0",
+                "@typescript-eslint/parser": "^8.37.0",
                 "eslint": "^8.57.0 || ^9.0.0",
                 "typescript": ">=4.8.4 <5.9.0"
             }
@@ -1285,16 +1285,16 @@
             }
         },
         "node_modules/@typescript-eslint/parser": {
-            "version": "8.36.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.36.0.tgz",
-            "integrity": "sha512-FuYgkHwZLuPbZjQHzJXrtXreJdFMKl16BFYyRrLxDhWr6Qr7Kbcu2s1Yhu8tsiMXw1S0W1pjfFfYEt+R604s+Q==",
+            "version": "8.37.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.37.0.tgz",
+            "integrity": "sha512-kVIaQE9vrN9RLCQMQ3iyRlVJpTiDUY6woHGb30JDkfJErqrQEmtdWH3gV0PBAfGZgQXoqzXOO0T3K6ioApbbAA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@typescript-eslint/scope-manager": "8.36.0",
-                "@typescript-eslint/types": "8.36.0",
-                "@typescript-eslint/typescript-estree": "8.36.0",
-                "@typescript-eslint/visitor-keys": "8.36.0",
+                "@typescript-eslint/scope-manager": "8.37.0",
+                "@typescript-eslint/types": "8.37.0",
+                "@typescript-eslint/typescript-estree": "8.37.0",
+                "@typescript-eslint/visitor-keys": "8.37.0",
                 "debug": "^4.3.4"
             },
             "engines": {
@@ -1310,14 +1310,14 @@
             }
         },
         "node_modules/@typescript-eslint/project-service": {
-            "version": "8.36.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.36.0.tgz",
-            "integrity": "sha512-JAhQFIABkWccQYeLMrHadu/fhpzmSQ1F1KXkpzqiVxA/iYI6UnRt2trqXHt1sYEcw1mxLnB9rKMsOxXPxowN/g==",
+            "version": "8.37.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.37.0.tgz",
+            "integrity": "sha512-BIUXYsbkl5A1aJDdYJCBAo8rCEbAvdquQ8AnLb6z5Lp1u3x5PNgSSx9A/zqYc++Xnr/0DVpls8iQ2cJs/izTXA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@typescript-eslint/tsconfig-utils": "^8.36.0",
-                "@typescript-eslint/types": "^8.36.0",
+                "@typescript-eslint/tsconfig-utils": "^8.37.0",
+                "@typescript-eslint/types": "^8.37.0",
                 "debug": "^4.3.4"
             },
             "engines": {
@@ -1332,14 +1332,14 @@
             }
         },
         "node_modules/@typescript-eslint/scope-manager": {
-            "version": "8.36.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.36.0.tgz",
-            "integrity": "sha512-wCnapIKnDkN62fYtTGv2+RY8FlnBYA3tNm0fm91kc2BjPhV2vIjwwozJ7LToaLAyb1ca8BxrS7vT+Pvvf7RvqA==",
+            "version": "8.37.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.37.0.tgz",
+            "integrity": "sha512-0vGq0yiU1gbjKob2q691ybTg9JX6ShiVXAAfm2jGf3q0hdP6/BruaFjL/ManAR/lj05AvYCH+5bbVo0VtzmjOA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@typescript-eslint/types": "8.36.0",
-                "@typescript-eslint/visitor-keys": "8.36.0"
+                "@typescript-eslint/types": "8.37.0",
+                "@typescript-eslint/visitor-keys": "8.37.0"
             },
             "engines": {
                 "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -1350,9 +1350,9 @@
             }
         },
         "node_modules/@typescript-eslint/tsconfig-utils": {
-            "version": "8.36.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.36.0.tgz",
-            "integrity": "sha512-Nhh3TIEgN18mNbdXpd5Q8mSCBnrZQeY9V7Ca3dqYvNDStNIGRmJA6dmrIPMJ0kow3C7gcQbpsG2rPzy1Ks/AnA==",
+            "version": "8.37.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.37.0.tgz",
+            "integrity": "sha512-1/YHvAVTimMM9mmlPvTec9NP4bobA1RkDbMydxG8omqwJJLEW/Iy2C4adsAESIXU3WGLXFHSZUU+C9EoFWl4Zg==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -1367,14 +1367,15 @@
             }
         },
         "node_modules/@typescript-eslint/type-utils": {
-            "version": "8.36.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.36.0.tgz",
-            "integrity": "sha512-5aaGYG8cVDd6cxfk/ynpYzxBRZJk7w/ymto6uiyUFtdCozQIsQWh7M28/6r57Fwkbweng8qAzoMCPwSJfWlmsg==",
+            "version": "8.37.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.37.0.tgz",
+            "integrity": "sha512-SPkXWIkVZxhgwSwVq9rqj/4VFo7MnWwVaRNznfQDc/xPYHjXnPfLWn+4L6FF1cAz6e7dsqBeMawgl7QjUMj4Ow==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@typescript-eslint/typescript-estree": "8.36.0",
-                "@typescript-eslint/utils": "8.36.0",
+                "@typescript-eslint/types": "8.37.0",
+                "@typescript-eslint/typescript-estree": "8.37.0",
+                "@typescript-eslint/utils": "8.37.0",
                 "debug": "^4.3.4",
                 "ts-api-utils": "^2.1.0"
             },
@@ -1391,9 +1392,9 @@
             }
         },
         "node_modules/@typescript-eslint/types": {
-            "version": "8.36.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.36.0.tgz",
-            "integrity": "sha512-xGms6l5cTJKQPZOKM75Dl9yBfNdGeLRsIyufewnxT4vZTrjC0ImQT4fj8QmtJK84F58uSh5HVBSANwcfiXxABQ==",
+            "version": "8.37.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.37.0.tgz",
+            "integrity": "sha512-ax0nv7PUF9NOVPs+lmQ7yIE7IQmAf8LGcXbMvHX5Gm+YJUYNAl340XkGnrimxZ0elXyoQJuN5sbg6C4evKA4SQ==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -1405,16 +1406,16 @@
             }
         },
         "node_modules/@typescript-eslint/typescript-estree": {
-            "version": "8.36.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.36.0.tgz",
-            "integrity": "sha512-JaS8bDVrfVJX4av0jLpe4ye0BpAaUW7+tnS4Y4ETa3q7NoZgzYbN9zDQTJ8kPb5fQ4n0hliAt9tA4Pfs2zA2Hg==",
+            "version": "8.37.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.37.0.tgz",
+            "integrity": "sha512-zuWDMDuzMRbQOM+bHyU4/slw27bAUEcKSKKs3hcv2aNnc/tvE/h7w60dwVw8vnal2Pub6RT1T7BI8tFZ1fE+yg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@typescript-eslint/project-service": "8.36.0",
-                "@typescript-eslint/tsconfig-utils": "8.36.0",
-                "@typescript-eslint/types": "8.36.0",
-                "@typescript-eslint/visitor-keys": "8.36.0",
+                "@typescript-eslint/project-service": "8.37.0",
+                "@typescript-eslint/tsconfig-utils": "8.37.0",
+                "@typescript-eslint/types": "8.37.0",
+                "@typescript-eslint/visitor-keys": "8.37.0",
                 "debug": "^4.3.4",
                 "fast-glob": "^3.3.2",
                 "is-glob": "^4.0.3",
@@ -1434,16 +1435,16 @@
             }
         },
         "node_modules/@typescript-eslint/utils": {
-            "version": "8.36.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.36.0.tgz",
-            "integrity": "sha512-VOqmHu42aEMT+P2qYjylw6zP/3E/HvptRwdn/PZxyV27KhZg2IOszXod4NcXisWzPAGSS4trE/g4moNj6XmH2g==",
+            "version": "8.37.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.37.0.tgz",
+            "integrity": "sha512-TSFvkIW6gGjN2p6zbXo20FzCABbyUAuq6tBvNRGsKdsSQ6a7rnV6ADfZ7f4iI3lIiXc4F4WWvtUfDw9CJ9pO5A==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@eslint-community/eslint-utils": "^4.7.0",
-                "@typescript-eslint/scope-manager": "8.36.0",
-                "@typescript-eslint/types": "8.36.0",
-                "@typescript-eslint/typescript-estree": "8.36.0"
+                "@typescript-eslint/scope-manager": "8.37.0",
+                "@typescript-eslint/types": "8.37.0",
+                "@typescript-eslint/typescript-estree": "8.37.0"
             },
             "engines": {
                 "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -1458,13 +1459,13 @@
             }
         },
         "node_modules/@typescript-eslint/visitor-keys": {
-            "version": "8.36.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.36.0.tgz",
-            "integrity": "sha512-vZrhV2lRPWDuGoxcmrzRZyxAggPL+qp3WzUrlZD+slFueDiYHxeBa34dUXPuC0RmGKzl4lS5kFJYvKCq9cnNDA==",
+            "version": "8.37.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.37.0.tgz",
+            "integrity": "sha512-YzfhzcTnZVPiLfP/oeKtDp2evwvHLMe0LOy7oe+hb9KKIumLNohYS9Hgp1ifwpu42YWxhZE8yieggz6JpqO/1w==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@typescript-eslint/types": "8.36.0",
+                "@typescript-eslint/types": "8.37.0",
                 "eslint-visitor-keys": "^4.2.1"
             },
             "engines": {
@@ -6512,15 +6513,16 @@
             }
         },
         "node_modules/typescript-eslint": {
-            "version": "8.36.0",
-            "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.36.0.tgz",
-            "integrity": "sha512-fTCqxthY+h9QbEgSIBfL9iV6CvKDFuoxg6bHPNpJ9HIUzS+jy2lCEyCmGyZRWEBSaykqcDPf1SJ+BfCI8DRopA==",
+            "version": "8.37.0",
+            "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.37.0.tgz",
+            "integrity": "sha512-TnbEjzkE9EmcO0Q2zM+GE8NQLItNAJpMmED1BdgoBMYNdqMhzlbqfdSwiRlAzEK2pA9UzVW0gzaaIzXWg2BjfA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@typescript-eslint/eslint-plugin": "8.36.0",
-                "@typescript-eslint/parser": "8.36.0",
-                "@typescript-eslint/utils": "8.36.0"
+                "@typescript-eslint/eslint-plugin": "8.37.0",
+                "@typescript-eslint/parser": "8.37.0",
+                "@typescript-eslint/typescript-estree": "8.37.0",
+                "@typescript-eslint/utils": "8.37.0"
             },
             "engines": {
                 "node": "^18.18.0 || ^20.9.0 || >=21.1.0"

--- a/package.json
+++ b/package.json
@@ -27,6 +27,6 @@
         "husky": "^9.1.7",
         "prettier": "^3.6.2",
         "typescript": "^5.8.3",
-        "typescript-eslint": "^8.36.0"
+        "typescript-eslint": "^8.37.0"
     }
 }


### PR DESCRIPTION
---
updated-dependencies:
- dependency-name: typescript-eslint dependency-version: 8.37.0 dependency-type: direct:development update-type: version-update:semver-minor dependency-group: minor_patch ...